### PR TITLE
Fix kubeconfig path in readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ go run main.go
 
 # Running as a container
 ```
-docker run -it --rm -v $HOME/.kube/config:/kubeconfig: quay.io/gravitational/cve-2018-1002105:latest
+docker run -it --rm -v $HOME/.kube/config/kubeconfig:/kubeconfig: quay.io/gravitational/cve-2018-1002105:latest
 ```
 
 # Testing a cluster


### PR DESCRIPTION
This commit resolves #9. There is a typo in the readme file.